### PR TITLE
Fix small typos in URL for WebSocket client connection

### DIFF
--- a/Project/Sources/Forms/HDI2/ObjectMethods/Button.4dm
+++ b/Project/Sources/Forms/HDI2/ObjectMethods/Button.4dm
@@ -1,4 +1,4 @@
-var $doc : Text
+var $url : Text
 
-$url:="http:///127.0.0.1:8080/ws client.htm"
-OPEN URL:C673($url)
+$url:="http://127.0.0.1:8080/ws client.htm"
+OPEN URL:C673($url; *)


### PR DESCRIPTION
Some typos fixed in this commit: 
- fix the variable declaration ($url instead of $doc)
- removed an additional and unnecessary / in url scheme
- used the OPEN URL with star parameter to convert automatically spaces in URL into %20 (and prevent assert with debug versions)